### PR TITLE
Expose post-css import path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ postcss: (ctx) => {
 
 | Name | Description | Default |
 | ---- | ----------- | ------- |
-| **root** | Root path used to resolve layouts and includes | Defaults to `webpack.options.context` which is the project root folder.|
+| **root** | Root path used to resolve layouts and includes | |
 | **path** | A path to a folder or an array of paths, telling postcss-import where to look for sss or css files to `@import`. | Defaults to the `assets/css` folder. |
 | **webpack** | Shortcut for webpack users to set the `root` and `addDependencyTo` options more easily. Pass webpack loader context. | |
 | **browsers** | Browser support provided to [autoprefixer](http://cssnext.io/usage/#browsers) | `> 1%, last 2 versions, Firefox ESR` |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ postcss: (ctx) => {
 | ---- | ----------- | ------- |
 | **root** | Root path used to resolve layouts and includes | |
 | **addDependencyTo** | Object with `addDependency` method that will get file paths for tracked deps from includes/layouts | |
+| **path** | A string or an array of paths to tell [postcss-import](https://github.com/postcss/postcss-import#path) where to look for files. | |
 | **webpack** | Shortcut for webpack users to set the `root` and `addDependencyTo` options more easily. Pass webpack loader context. | |
 | **browsers** | Browser support provided to [autoprefixer](http://cssnext.io/usage/#browsers) | `> 1%, last 2 versions, Firefox ESR` |
 | **features** | Enable or disable [cssnext features](http://cssnext.io/usage/#features) | |

--- a/README.md
+++ b/README.md
@@ -61,9 +61,8 @@ postcss: (ctx) => {
 
 | Name | Description | Default |
 | ---- | ----------- | ------- |
-| **root** | Root path used to resolve layouts and includes | |
-| **addDependencyTo** | Object with `addDependency` method that will get file paths for tracked deps from includes/layouts | |
-| **path** | A string or an array of paths to tell [postcss-import](https://github.com/postcss/postcss-import#path) where to look for files. | |
+| **root** | Root path used to resolve layouts and includes | Defaults to `webpack.options.context` which is the project root folder.|
+| **path** | A path to a folder or an array of paths, telling postcss-import where to look for sss or css files to `@import`. | Defaults to the `assets/css` folder. |
 | **webpack** | Shortcut for webpack users to set the `root` and `addDependencyTo` options more easily. Pass webpack loader context. | |
 | **browsers** | Browser support provided to [autoprefixer](http://cssnext.io/usage/#browsers) | `> 1%, last 2 versions, Firefox ESR` |
 | **features** | Enable or disable [cssnext features](http://cssnext.io/usage/#features) | |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ postcss: (ctx) => {
 
 | Name | Description | Default |
 | ---- | ----------- | ------- |
-| **root** | Root path used to resolve layouts and includes | |
+| **root** | Root path used to resolve layouts and includes | Defaults to `webpack.options.context` which is the project root folder.|
+| **path** | A path string or an array of paths telling postcss-import where to look for sss or css files to `@import`. | Defaults to the `assets/css` folder. |
 | **addDependencyTo** | Object with `addDependency` method that will get file paths for tracked deps from includes/layouts | |
 | **path** | A string or an array of paths to tell [postcss-import](https://github.com/postcss/postcss-import#path) where to look for files. | |
 | **webpack** | Shortcut for webpack users to set the `root` and `addDependencyTo` options more easily. Pass webpack loader context. | |

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ module.exports = (options = {}) => {
   }
 
   // standard options merge
-  const importOpt = selectiveMerge(options, ['root', 'addDependencyTo', 'path' ])
+  const importOpt = selectiveMerge(options, ['root', 'addDependencyTo', 'path'])
   const cssnextOpt = selectiveMerge(options, ['browsers', 'features', 'warnForDuplicates'])
 
   // define normal plugin list

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,11 @@ module.exports = (options = {}) => {
   // sugarss by default unless false or custom parser
   let parser = options.parser || sugarss
   if (options.parser === false) parser = undefined
+  options.path = options.path ? Array.prototype.concat(options.path) : []
 
   // define addDependencyTo if the webpack object is provided
   if (options.webpack) {
     options.root = options.webpack.options.context
-    options.path = options.path ? Array.prototype.concat(options.path) : []
     options.path.push(options.webpack.resourcePath)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,9 @@ module.exports = (options = {}) => {
 
   // define addDependencyTo if the webpack object is provided
   if (options.webpack) {
-    options.root = options.webpack.resourcePath
-    options.addDependencyTo = options.webpack
+    options.root = options.webpack.options.context
+    options.path = options.path ? Array.prototype.concat(options.path) : []
+    options.path.push(options.webpack.resourcePath)
   }
 
   // standard options merge

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ module.exports = (options = {}) => {
   }
 
   // standard options merge
-  const importOpt = selectiveMerge(options, ['root', 'addDependencyTo'])
+  const importOpt = selectiveMerge(options, ['root', 'addDependencyTo', 'path' ])
   const cssnextOpt = selectiveMerge(options, ['browsers', 'features', 'warnForDuplicates'])
 
   // define normal plugin list

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "coveralls": "^2.11.12",
     "nyc": "^10.0.0",
     "rewire": "^2.5.2",
-    "snazzy": "^5.0.0",
+    "snazzy": "^6.0.0",
     "standard": "^8.0.0"
   },
   "engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,9 @@ const test = require('ava')
 test('basic', (t) => {
   cssStandardsRewired.__set__('postcssImport', (opts) => {
     t.truthy(opts.root === 'test')
-    t.truthy(opts.addDependencyTo.addDependency === 'test')
-    t.truthy(opts.path[0] === 'test/test')
+    t.truthy(opts.path[0] === 'test/test1')
+    t.truthy(opts.path[1] === 'test/test2')
+    t.truthy(opts.path[2] === 'test') // webpack.resourcePath
   })
 
   cssStandardsRewired.__set__('cssnext', (opts) => {
@@ -22,8 +23,12 @@ test('basic', (t) => {
 
   const out1 = cssStandardsRewired({
     parser: false,
-    webpack: { resourcePath: 'test', addDependency: 'test' },
-    path: ['test/test'],
+    webpack: {
+      resourcePath: 'test',
+      addDependency: 'test',
+      options: { context: 'test' }
+    },
+    path: ['test/test1', 'test/test2'],
     features: 'test',
     browsers: 'test',
     warnForDuplicates: 'test',

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ test('basic', (t) => {
   cssStandardsRewired.__set__('postcssImport', (opts) => {
     t.truthy(opts.root === 'test')
     t.truthy(opts.addDependencyTo.addDependency === 'test')
+    t.truthy(opts.path[0] === 'test/test')
   })
 
   cssStandardsRewired.__set__('cssnext', (opts) => {
@@ -22,6 +23,7 @@ test('basic', (t) => {
   const out1 = cssStandardsRewired({
     parser: false,
     webpack: { resourcePath: 'test', addDependency: 'test' },
+    path: ['test/test'],
     features: 'test',
     browsers: 'test',
     warnForDuplicates: 'test',


### PR DESCRIPTION
Expose path option of post-css-import in Spike CSS Standards

This allows to specify local directories to directly @import css modules from.